### PR TITLE
remove dependency on ember-mobile-core

### DIFF
--- a/addon/modifiers/did-pan.js
+++ b/addon/modifiers/did-pan.js
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { parseInitialTouchData, parseTouchData, isHorizontal, isVertical } from 'ember-mobile-core/utils/parse-touch-data';
+import { parseInitialTouchData, parseTouchData, isHorizontal, isVertical } from '../utils/parse-touch-data';
 import { action } from '@ember/object';
 
 const _fn = () => {};

--- a/addon/utils/parse-touch-data.js
+++ b/addon/utils/parse-touch-data.js
@@ -1,0 +1,171 @@
+/**
+ * Generate initial touch data for passed Touch
+ *
+ * @function parseInitialTouchData
+ * @param {Touch} touch A Touch instance
+ * @param {TouchEvent} e The touch{start,move,end} event
+ * @return {Object} Returns a TouchData object
+ * @private
+ */
+export function parseInitialTouchData(touch, e){
+  return {
+    data: {
+      initial: {
+        x: touch.clientX,
+        y: touch.clientY,
+        timeStamp: e.timeStamp
+      },
+      cache: {
+        velocity: {
+          distanceX: 0,
+          distanceY: 0,
+          timeStamp: e.timeStamp
+        }
+      },
+      timeStamp: e.timeStamp,
+      originalEvent: e
+    },
+    panStarted: false,
+    panDenied: false,
+  }
+}
+
+/**
+ * Generates useful touch data from current event based on previously generated data
+ *
+ * @function parseTouchData
+ * @param {Object} previousTouchData Previous data returned by this or the parseInitialTouchData function
+ * @param {Touch} touch A Touch instance
+ * @param {TouchEvent} e The touch{start,move,end} event
+ * @return {Object} The new touch data
+ * @private
+ */
+export function parseTouchData(previousTouchData, touch, e) {
+  const touchData = {...previousTouchData};
+  const data = touchData.data;
+
+  if(data.current){
+    data.current.deltaX = touch.clientX - data.current.x;
+    data.current.deltaY = touch.clientY - data.current.y;
+  } else {
+    data.current = {};
+    data.current.deltaX = touch.clientX - data.initial.x;
+    data.current.deltaY = touch.clientY - data.initial.y;
+  }
+
+  data.current.x = touch.clientX;
+  data.current.y = touch.clientY;
+  data.current.distance = getPointDistance(data.initial.x, touch.clientX, data.initial.y, touch.clientY);
+  data.current.distanceX = touch.clientX - data.initial.x;
+  data.current.distanceY = touch.clientY - data.initial.y;
+  data.current.angle = getAngle(data.initial.x, data.initial.y,  touch.clientX, touch.clientY);
+
+  // overallVelocity can be calculated continuously
+  const overallDeltaTime = e.timeStamp - data.initial.timeStamp;
+  data.current.overallVelocityX = data.current.distanceX / overallDeltaTime || 0;
+  data.current.overallVelocityY = data.current.distanceY / overallDeltaTime || 0;
+  data.current.overallVelocity = Math.abs(data.current.overallVelocityX) > Math.abs(data.current.overallVelocityY)
+    ? data.current.overallVelocityX
+    : data.current.overallVelocityY;
+
+  // we don't update the velocity on the final touchend event as nothing but the timestamp has changed
+  // which always results in a velocity of 0
+  if(e.type !== 'touchend'){
+    const deltaTime = e.timeStamp - data.cache.velocity.timeStamp;
+
+    data.current.velocityX = (data.current.distanceX - data.cache.velocity.distanceX) / deltaTime || 0;
+    data.current.velocityY = (data.current.distanceY - data.cache.velocity.distanceY) / deltaTime || 0;
+    data.current.velocity = Math.abs(data.current.velocityX) > Math.abs(data.current.velocityY)
+      ? data.current.velocityX
+      : data.current.velocityY;
+
+    data.cache.velocity = {
+      distanceX: data.current.distanceX,
+      distanceY: data.current.distanceY,
+      timeStamp: e.timeStamp
+    };
+  }
+
+  data.originalEvent = e;
+  data.timeStamp = e.timeStamp;
+
+  touchData.data = data;
+
+  return touchData;
+}
+
+/**
+ * Calculates whether or not the movement went left or right
+ *
+ * @function isHorizontal
+ * @param {TouchData} touchData A POJO as returned from `parseInitialTouchData` or `parseTouchData`
+ * @return {boolean} True if horizontal
+ * @private
+ */
+export function isHorizontal(touchData){
+  const direction = getDirection(touchData.data.current.distanceX, touchData.data.current.distanceY);
+  return direction === 'left' || direction === 'right';
+}
+
+/**
+ * Calculates whether or not the movement went up or down
+ *
+ * @function isVertical
+ * @param {TouchData} touchData A POJO as returned from `parseInitialTouchData` or `parseTouchData`
+ * @return {boolean} true if vertical
+ * @private
+ */
+export function isVertical(touchData){
+  const direction = getDirection(touchData.data.current.distanceX, touchData.data.current.distanceY);
+  return direction === 'down' || direction === 'up';
+}
+
+/**
+ * Calculates the direction of the touch movement
+ *
+ * @function getDirection
+ * @param {Number} x The distance moved from the origin on the X axis
+ * @param {Number} y The the distance moved from the origin on the Y axis
+ * @return {string} The direction of the pan event. One of 'left', 'right', 'up', 'down'.
+ * @private
+ */
+function getDirection(x, y) {
+  if(x === y){
+    return 'none';
+  } else if(Math.abs(x) >= Math.abs(y)){
+    return x < 0 ? 'left' : 'right';
+  } else {
+    return y < 0 ? 'down' : 'up';
+  }
+}
+
+/**
+ * Calculates the distance between two points
+ *
+ * @function getPointDistance
+ * @param {number} x0 X coordinate of the origin
+ * @param {number} x1 X coordinate of the current position
+ * @param {number} y0 Y coordinate of the origin
+ * @param {number} y1 Y coordinate of the current position
+ * @return {number} Distance between the two points
+ * @private
+ */
+function getPointDistance(x0, x1, y0, y1) {
+  return (Math.sqrt(((x1 - x0) * (x1 - x0)) + ((y1 - y0) * (y1 - y0))));
+}
+
+/**
+ * Calculates the angle between two points.
+ *
+ * @function getAngle
+ * @param {number} originX
+ * @param {number} originY
+ * @param {number} projectionX
+ * @param {number} projectionY
+ * @return {number} Angle between the two points
+ * @private
+ */
+function getAngle(originX, originY, projectionX, projectionY) {
+  const angle = Math.atan2(projectionY - originY, projectionX - originX) * ((180) / Math.PI);
+  return 360 - ((angle < 0) ? (360 + angle) : angle);
+}

--- a/app/utils/parse-touch-data.js
+++ b/app/utils/parse-touch-data.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-gesture-modifiers/utils/parse-touch-data';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "ember-cli-babel": "^7.17.2",
     "ember-cli-htmlbars": "^4.2.2",
-    "ember-mobile-core": "^0.2.0",
     "ember-modifier": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-gesture-modifiers",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/helpers/create-mock-touch-event.js
+++ b/tests/helpers/create-mock-touch-event.js
@@ -1,0 +1,24 @@
+/**
+ * Generates a mock touchEvent like object for testing purposes
+ * @param {string} eventType touchstart, touchmove or touchend
+ * @param {number} x
+ * @param {number} y
+ * @param {number} timeStampDelta
+ * @returns {{type: *, touches: Touch[], changedTouches: Touch[], timeStamp: number}}
+ */
+export default function createTouchEvent(eventType, x, y, timeStampDelta = 0) {
+  let touch = new Touch({
+    identifier: Date.now(),
+    target: window,
+    clientX: x,
+    clientY: y
+  });
+
+  // we mock it using an object because we can't otherwise set the timeStamp
+  return {
+    type: eventType,
+    touches: [touch],
+    changedTouches: [touch],
+    timeStamp: 234011.29999995464 + timeStampDelta
+  };
+}

--- a/tests/unit/utils/parse-touch-data-test.js
+++ b/tests/unit/utils/parse-touch-data-test.js
@@ -1,0 +1,123 @@
+import {
+  parseInitialTouchData,
+  parseTouchData,
+  isHorizontal,
+  isVertical
+} from 'ember-gesture-modifiers/utils/parse-touch-data';
+import { module, test } from 'qunit';
+import createTouchEvent from '../../helpers/create-mock-touch-event';
+
+module('Unit | Utility | parse-touch-data', function() {
+  test('it returns the initial touch data', function(assert) {
+    const e = createTouchEvent('touchmove', 0, 0);
+    let touch = e.changedTouches[0];
+    let touchData = parseInitialTouchData(touch, e);
+
+    assert.deepEqual(touchData, {
+      data: {
+        initial: {
+          x: touch.clientX,
+          y: touch.clientY,
+          timeStamp: e.timeStamp
+        },
+        cache: {
+          velocity: {
+            distanceX: 0,
+            distanceY: 0,
+            timeStamp: e.timeStamp
+          }
+        },
+        timeStamp: e.timeStamp,
+        originalEvent: e
+      },
+      panStarted: false,
+      panDenied: false,
+    });
+  });
+
+  test('it returns the parsed touch data', async function(assert) {
+    const e1 = createTouchEvent('touchmove', 0, 0);
+    const e2 = createTouchEvent('touchmove', 42, 33, 52);
+    let initialTouchData = parseInitialTouchData(e1.changedTouches[0], e1);
+    let touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+
+    assert.deepEqual(touchData, {
+      data: {
+        cache: {
+          velocity: {
+            distanceX: 42,
+            distanceY: 33,
+            timeStamp: e2.timeStamp
+          }
+        },
+        current: {
+          angle: 321.84277341263095,
+          deltaX: 42,
+          deltaY: 33,
+          distance: 53.41348144429457,
+          distanceX: 42,
+          distanceY: 33,
+          overallVelocity: 0.8076923076923077,
+          overallVelocityX: 0.8076923076923077,
+          overallVelocityY: 0.6346153846153846,
+          velocity: 0.8076923076923077,
+          velocityX: 0.8076923076923077,
+          velocityY: 0.6346153846153846,
+          x: 42,
+          y: 33
+        },
+        initial: initialTouchData.data.initial,
+        originalEvent: e2,
+        timeStamp: e2.timeStamp
+      },
+      panDenied: false,
+      panStarted: false
+    });
+  });
+
+  test('it detects a touch as horizontal', function(assert) {
+    assert.expect(4);
+
+    let e1 = createTouchEvent('touchmove', 0, 0);
+    let initialTouchData = parseInitialTouchData(e1.changedTouches[0], e1);
+
+    let e2 = createTouchEvent('touchmove', 42, 33, 52);
+    let touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isHorizontal(touchData), true);
+
+    e2 = createTouchEvent('touchmove', -42, -33, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isHorizontal(touchData), true);
+
+    e2 = createTouchEvent('touchmove', 0, 0, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isHorizontal(touchData), false);
+
+    e2 = createTouchEvent('touchmove', -33, -42, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isHorizontal(touchData), false);
+  });
+
+  test('it detects a touch as vertical', function(assert) {
+    assert.expect(4);
+
+    let e1 = createTouchEvent('touchmove', 0, 0);
+    let initialTouchData = parseInitialTouchData(e1.changedTouches[0], e1);
+
+    let e2 = createTouchEvent('touchmove', 42, 33, 52);
+    let touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isVertical(touchData), false);
+
+    e2 = createTouchEvent('touchmove', -42, -33, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isVertical(touchData), false);
+
+    e2 = createTouchEvent('touchmove', 0, 0, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isVertical(touchData), false);
+
+    e2 = createTouchEvent('touchmove', -33, -42, 52);
+    touchData = parseTouchData(initialTouchData, e2.changedTouches[0], e2);
+    assert.equal(isVertical(touchData), true);
+  })
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,7 +4139,7 @@ ember-assign-polyfill@^2.6.0:
     ember-cli-babel "^6.16.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-auto-import@^1.2.13, ember-auto-import@^1.5.3:
+ember-auto-import@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.5.3.tgz#b32936f874d1ed7057ad2ed3f6116357820be44b"
   integrity sha512-7JfdunM1BmLy/lyUXu7uEoi0Gi4+dxkGM23FgIEyW5g7z4MidhP53Fc61t49oPSnq7+J4lLpbH1f6C+mDMgb4A==
@@ -4197,7 +4197,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.7.3:
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.18.0.tgz#e979b73eee00cd93f63452c6170d045e8832f29c"
   integrity sha512-OLPfYD8wSfCrmGHcUf8zEfySSvbAL+5Qp2RWLycJIMaBZhg+SncKj5kVkL3cPJR5n2hVHPdfmKTQIYjOYl6FnQ==
@@ -4563,15 +4563,6 @@ ember-maybe-import-regenerator@^0.1.6:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
-
-ember-mobile-core@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-mobile-core/-/ember-mobile-core-0.2.0.tgz#bac4ba0ccdfdf360e5753526613026b14b457d60"
-  integrity sha512-kHxIF/AIc4CLePSo+8jlUm3Z2WYxZTda7HfgO/a0bUJLqa2sEtWTTrqh0LV/Y2yh9zmjL2uwRZOGFyRcx1dYjw==
-  dependencies:
-    ember-auto-import "^1.2.13"
-    ember-cli-babel "^7.1.2"
-    wobble "^1.5.0"
 
 ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
@@ -10324,11 +10315,6 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
-
-wobble@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/wobble/-/wobble-1.5.1.tgz#2f2d50b6a54597eef765a688a9b9c56c87ecd606"
-  integrity sha512-vQD1uu0yXhZWfQJKVf2UVNb3AVnD0qXAbcIqG6Aw02ABLVm77xz6KcLuduWSwOiOMNh8TjZqouZsHTJWTdLwVQ==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This internalises the parseTouchData utility functions and as such removes the dependency on ember-mobile-core.