### PR TITLE
add bidirectional pan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Currently only a Pan modifier is provided. More gestures will be added in the fu
  - **onPan** - hook fired when the pan is updated
  - **onPanEnd** - hook fired when a pan has ended
  - **threshold** _(default: 10)_ - minimum touch movement needed in px to start a pan
- - **axis** _(default: 'horizontal')_ - axis for the pan event to be recognized ('horizontal' or 'vertical')
+ - **axis** _(default: 'horizontal')_ - axis for the pan event to be recognized ('horizontal', 'vertical' or 'both')
  - **capture** _(default: false)_ - whether or not to use capture events instead of bubbling
  - **preventScroll** _(default: true)_ - whether or not to prevent scroll during panning
  - **pointerTypes** _(default: ['touch'])_ - the pointer types to support (one or more of 'touch', 'mouse', 'pen')

--- a/addon/modifiers/did-pan.js
+++ b/addon/modifiers/did-pan.js
@@ -22,6 +22,8 @@ export default class DidPanModifier extends Modifier {
       this.element.style.touchAction = 'pan-y';
     } else if(this.axis === 'vertical') {
       this.element.style.touchAction = 'pan-x';
+    } else if (this.axis === 'both') {
+      this.element.style.touchAction = 'none';
     }
 
     this.element.addEventListener('pointerdown', this.didTouchStart, { capture: this.useCapture, passive: true });
@@ -69,11 +71,13 @@ export default class DidPanModifier extends Modifier {
           && (
             (this.axis === 'horizontal' && Math.abs(touchData.data.current.distanceX) > this.threshold)
             || (this.axis === 'vertical' && Math.abs(touchData.data.current.distanceY) > this.threshold)
+            || (this.axis === 'both' && Math.abs(touchData.data.current.distance) > this.threshold)
           )
         ){
           // test if axis matches with data else deny the pan
           if(  (this.axis === 'horizontal' && isHorizontal(touchData))
             || (this.axis === 'vertical' && isVertical(touchData))
+            || this.axis === 'both'
           ){
             // prevent scroll if a pan is detected
             if(this.preventScroll){

--- a/tests/integration/modifiers/did-pan-test.js
+++ b/tests/integration/modifiers/did-pan-test.js
@@ -64,5 +64,28 @@ module('Integration | Modifier | did-pan', function(hooks) {
     assert.equal(didStart, false, 'onPanStart should not have been called');
   });
 
-  // TODO: vertical pan tests (axis=vertical)
+  test(`it sets the correect touch-action for the passed axis`, async function(assert) {
+    await render(hbs`<div data-test-div class="did-pan" {{did-pan axis=this.axis}} style="width: 50px; height: 10px; background: red"></div>`);
+
+    assert.dom('[data-test-div]').hasStyle({
+      'touch-action': 'pan-y'
+    });
+
+    this.set('axis', 'vertical');
+    assert.dom('[data-test-div]').hasStyle({
+      'touch-action': 'pan-x'
+    });
+
+    this.set('axis', 'horizontal');
+    assert.dom('[data-test-div]').hasStyle({
+      'touch-action': 'pan-y'
+    });
+
+    this.set('axis', 'both');
+    assert.dom('[data-test-div]').hasStyle({
+      'touch-action': 'none'
+    });
+  });
+
+  // TODO: vertical/bi-directional pan tests (axis=vertical,both)
 });


### PR DESCRIPTION
This adds support for an `axis="both"` argument which allows for a bidirectional pan (both horizontal and vertical) without the browser interfering.