### PR TITLE
Add ember-auto-import to dependencies to support v2 addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "ember-auto-import": "2.6.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.0",
     "ember-modifier": "^3.2.0"
@@ -39,7 +40,6 @@
     "@glimmer/tracking": "1.1.2",
     "babel-eslint": "10.1.0",
     "broccoli-asset-rev": "3.0.0",
-    "ember-auto-import": "2.6.0",
     "ember-cli": "4.10.0",
     "ember-cli-dependency-checker": "3.3.1",
     "ember-cli-inject-live-reload": "2.1.0",


### PR DESCRIPTION
Mainly needed for ember-modifier v4 support