### PR TITLE
Configure ember-source peerDependency as >=3.28.0 to allow for v5 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "webpack": "5.75.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": ">=3.28.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Should fix ember-canary CI job